### PR TITLE
Adiciona o parâmetro pressao_hpa na resposta para o endpoint consolidado

### DIFF
--- a/estacao/repositories/consolidado.py
+++ b/estacao/repositories/consolidado.py
@@ -1,4 +1,5 @@
 from estacao.models import Consolidado
+from estacao.normalize import Normalize
 
 
 class ConsolidadoRepository:
@@ -52,6 +53,15 @@ class ConsolidadoRepository:
             dict_key = keys[item]
             data_dict[dict_key] = data[item]
         return data_dict
+
+    def set_pressao_hpa(self):
+        data = getattr(self, 'data')
+        normalize = Normalize()
+        for item in data:
+            pressao = item.get('pressao')
+            temp_bar = item.get('temp_bar')
+            pressao_hpa = normalize.trans_p(pressao, temp_bar)
+            item['pressao_hpa'] = pressao_hpa
 
     def set_date(self):
         for row in self.data:

--- a/estacao/repositories/consolidado.py
+++ b/estacao/repositories/consolidado.py
@@ -1,6 +1,8 @@
 from estacao.models import Consolidado
 from estacao.normalize import Normalize
 
+FLOAT_ROUND = 2
+
 
 class ConsolidadoRepository:
     def __init__(self, date_ini, date_end):
@@ -62,7 +64,7 @@ class ConsolidadoRepository:
             pressao = item.get('pressao')
             temp_bar = item.get('temp_bar')
             pressao_hpa = normalize.trans_p(pressao, temp_bar)
-            item['pressao_hpa'] = pressao_hpa
+            item['pressao_hpa'] = round(pressao_hpa, FLOAT_ROUND)
 
     def set_date(self):
         for row in self.data:

--- a/estacao/repositories/consolidado.py
+++ b/estacao/repositories/consolidado.py
@@ -12,6 +12,7 @@ class ConsolidadoRepository:
         self.make_query()
         self.set_data()
         self.to_dict()
+        self.set_pressao_hpa()
         self.set_date()
         return self.data
 

--- a/estacao/tests/test_repositories.py
+++ b/estacao/tests/test_repositories.py
@@ -172,3 +172,11 @@ class TestConsolidadoRepository:
         expected = consolidado.query.first().to_dict()
         expected.pop('id')
         assert expected == repository_values
+
+    def test_set_hpa(self):
+        repository = ConsolidadoRepository('2018-01-01', '2018-12-12')
+        repository.make_query()
+        repository.set_data()
+        repository.to_dict()
+        repository.set_pressao_hpa()
+        assert 'pressao_hpa' in repository.data[0].keys()

--- a/estacao/tests/test_repositories.py
+++ b/estacao/tests/test_repositories.py
@@ -171,7 +171,8 @@ class TestConsolidadoRepository:
         repository_values = repository.all()[0]
         expected = consolidado.query.first().to_dict()
         expected.pop('id')
-        assert expected == repository_values
+        for key in expected.keys():
+            assert expected.get(key) == repository_values.get(key)
 
     def test_set_hpa(self):
         repository = ConsolidadoRepository('2018-01-01', '2018-12-12')


### PR DESCRIPTION
-  Adiciona o parâmetro pressao_hpa
-  Chama o método set_pressao_hpa
-  Arredonda o valor do parâmetro pressao_hpa
-  Testa os valores para ConsolidadoRepository
